### PR TITLE
feat: add adaptive resolution slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,10 @@
     </div>
 </div>
 <div class="solid-border-box">
-    <input type="range" id="patternSlider" min="1" max="5" value="1">
+    <div class="sliders">
+        <input type="range" id="patternSlider" min="1" max="5" value="1">
+        <input type="range" id="resolutionSlider" min="1" max="50" value="24">
+    </div>
     <div id="the-buttons">
         <button id="saveButton">Save as SVG</button>
         <button id="invertButton">Invert</button>
@@ -45,8 +48,6 @@
             <option value="4:3">4:3</option>
             <option value="16:9">16:9</option>
         </select>
-        <label for="resolutionSlider">Resolution</label>
-        <input type="range" id="resolutionSlider" min="1" max="120" value="24">
     </div>
 </div>
 <div class="footer-bar">

--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
             <option value="4:3">4:3</option>
             <option value="16:9">16:9</option>
         </select>
+        <label for="resolutionSlider">Resolution</label>
+        <input type="range" id="resolutionSlider" min="1" max="120" value="24">
     </div>
 </div>
 <div class="footer-bar">

--- a/styles.css
+++ b/styles.css
@@ -100,13 +100,9 @@ select:focus {
     box-shadow: 0 0 0 3px rgba(0, 255, 0, 0.3);
 }
 
-#resolutionSlider {
-    width: 20%;
-}
-
 input[type="range"] {
     -webkit-appearance: none;
-    width: 100%;
+    width: 50%;
     height: 15px;
     background: var(--secondary-color);
     border-radius: 5px;
@@ -178,6 +174,12 @@ label {
     flex-wrap: wrap;
     gap: 10px;
     align-items: center;
+    justify-content: space-around;
+}
+
+.sliders {
+    display: flex;
+    justify-content: center;
 }
 
 .solid-border-box {
@@ -194,7 +196,7 @@ label {
 
 .bottom-space {
     width: 100%;
-    height: 50px;
+    height: 100px;
     flex-shrink: 0;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -19,8 +19,8 @@ html, body {
 body {
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: space-between;
     height: 100vh;
     background-color: var(--secondary-color);
     color: var(--primary-color);
@@ -28,9 +28,6 @@ body {
     font-size: 13px;
     font-weight: 300;
     font-feature-settings: "ss03" 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
 }
 
 a {
@@ -66,6 +63,7 @@ button, input[type="color"], select {
 #secondaryColorPicker {
     background-color: var(--secondary-color);
 }
+
 #secondaryColorPicker:hover {
     background-color: var(--primary-color);
 }
@@ -102,6 +100,10 @@ select:focus {
     box-shadow: 0 0 0 3px rgba(0, 255, 0, 0.3);
 }
 
+#resolutionSlider {
+    width: 20%;
+}
+
 input[type="range"] {
     -webkit-appearance: none;
     width: 100%;
@@ -133,6 +135,7 @@ input[type="range"]::-moz-range-thumb {
 }
 
 label {
+    margin-top: 20px;
     color: var(--primary-color);
 }
 
@@ -186,9 +189,7 @@ label {
     border-color: var(--primary-color);
     border-width: 1px;
     width: 80%;
-    padding: 25px;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding: 10px 25px;
 }
 
 .bottom-space {


### PR DESCRIPTION
Whenever the aspect ratio is changed, the size of the canvas is changed such that pixels stay square. Also, a resolution slider has been added, allowing the user to reduce or increase the total number of dots in a different way, which works with all dithers, albeit with some artifacts at higher resolutions (mitigated by enabling image-rendering: smooth) when the canvas size approaches the canvas client size.